### PR TITLE
Use 3.11 as base to build powa-web images

### DIFF
--- a/powa-web-git/Containerfile
+++ b/powa-web-git/Containerfile
@@ -1,5 +1,5 @@
 #vim:set ft=dockerfile
-FROM debian:stable-slim
+FROM python:3.11-slim
 MAINTAINER Julien Rouhaud <rjuju123@gmail.com>
 
 WORKDIR /usr/local/src
@@ -7,13 +7,10 @@ WORKDIR /usr/local/src
 RUN apt-get update && apt-get install -y \
     libpq5 \
     libpq-dev \
-    python3 \
-    python3-dev \
-    python3-pip \
     git \
     && git clone https://github.com/powa-team/powa-web.git powa-web.git \
-    && pip3 install psycopg2 sqlalchemy tornado \
-    && apt-get purge -y --auto-remove libpq-dev python3-dev python3-pip git \
+    && pip3 install psycopg2-binary sqlalchemy tornado \
+    && apt-get purge -y --auto-remove libpq-dev git \
     && rm -rf /var/lib/apt/lists/*
 
 COPY powa-web.conf /etc/

--- a/powa-web/Containerfile
+++ b/powa-web/Containerfile
@@ -1,5 +1,5 @@
 #vim:set ft=dockerfile
-FROM debian:stable-slim
+FROM python:3.11-slim
 MAINTAINER Julien Rouhaud <rjuju123@gmail.com>
 
 WORKDIR /usr/local/src
@@ -7,12 +7,10 @@ WORKDIR /usr/local/src
 RUN apt-get update && apt-get install -y \
     libpq5 \
     libpq-dev \
-    python3 \
-    python3-dev \
-    python3-pip \
-    && pip3 install "sqlalchemy<2.0.0" \
-    && pip3 install powa-web \
-    && apt-get purge -y --auto-remove libpq-dev python3-dev python3-pip \
+    gcc \
+    && pip install "sqlalchemy<2.0.0" \
+    && pip install powa-web \
+    && apt-get purge -y --auto-remove libpq-dev gcc \
     && rm -rf /var/lib/apt/lists/*
 
 COPY powa-web.conf /etc/


### PR DESCRIPTION
Otherwise image fails to build with error:

error: externally-managed-environment
× This environment is externally managed

For powa-web-git, psycopg2-binary is required sufficient.