### PR TITLE
Provide primary port for standby in powa_remove_mode.yml

### DIFF
--- a/compose/powa_remote_mode.yml
+++ b/compose/powa_remote_mode.yml
@@ -56,4 +56,5 @@ services:
       POSTGRES_HOST_AUTH_METHOD: 'trust'
       POWA_ROLE: 'STANDBY'
       POWA_PRIMARY: 'remote-primary'
+      POWA_PRIMARY_PORT: 5433
       POWA_LOCAL_SNAPSHOT: 'NO'


### PR DESCRIPTION
Without this standby could not connect to primary since it was using the default 5432 port.