### PR TITLE
powa-collector: don't expose port 8888

### DIFF
--- a/powa-collector/Containerfile
+++ b/powa-collector/Containerfile
@@ -14,5 +14,4 @@ RUN apt-get update && apt-get install -y \
 
 COPY powa-collector.conf /etc/
 
-EXPOSE 8888
 CMD ["powa-collector.py"]


### PR DESCRIPTION
powa-collector doesn't listen to this port or any port, this is probably a copy/paste error from powa-web image.

Thanks to Alexander Povolotsky for the report.