### PR TITLE
Remove egrep usage

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -183,7 +183,7 @@ function build_image {
     fi
 
     # Update base image
-    base_image=$(egrep "^FROM " "${img_dir}/Containerfile" | sed 's/FROM //')
+    base_image=$(grep -E "^FROM " "${img_dir}/Containerfile" | sed 's/FROM //')
     echo "Pulling ${base_image}..."
     podman pull "${base_image}"
 
@@ -259,7 +259,7 @@ if should_be_built "powa-archivist"; then
     fi
 
     BASEDIR="$DIRNAME/powa-archivist"
-    for version in $(ls "$BASEDIR" | egrep '[0-9](+\.[0-9]+)?'); do
+    for version in $(ls "$BASEDIR" | grep -E '^[0-9]+(\.[0-9]+)?$'); do
         # filter subversion if asked
         if [[ -n "${specific_subver}" && "${specific_subver}" != "${version}" ]]; then
             continue

--- a/powa-archivist/update.sh
+++ b/powa-archivist/update.sh
@@ -34,7 +34,7 @@ echo "hypopg: ${HYPOPG_VERSION}"
 echo "pg_track_settings: ${PGTS_VERSION}"
 echo "pg_wait_sampling: ${PGWS_VERSION}"
 
-for pg_version in $(ls "${cur_dir}"| egrep '[0-9]+(\.[0-9]+)?'); do
+for pg_version in $(ls "${cur_dir}"| grep -E '[0-9]+(\.[0-9]+)?'); do
     echo "Setting up powa-archivist-${pg_version}..."
     echo ""
 


### PR DESCRIPTION
egrep is actively deprecated, yielding warnings on recent platform.  Replace all calls with "grep -E" to avoid any future problem.